### PR TITLE
docs: Add module graph visualization to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,37 @@ cmp-app-recipes/
 └── .github/            # GitHub Actions workflows
 ```
 
+## Module Graph
+
+```mermaid
+%%{
+  init: {
+    'theme': 'neutral'
+  }
+}%%
+
+graph LR
+  subgraph :core
+    :core:designsystem["designsystem"]
+    :core:network["network"]
+  end
+  subgraph :feature
+    :feature:login["login"]
+  end
+  :shared --> :core:designsystem
+  :shared --> :core:network
+  :shared --> :feature:login
+  :androidApp --> :shared
+
+classDef kotlin-multiplatform fill:#C792EA,stroke:#fff,stroke-width:2px,color:#fff;
+classDef android-application fill:#2C4162,stroke:#fff,stroke-width:2px,color:#fff;
+class :shared kotlin-multiplatform
+class :core:designsystem kotlin-multiplatform
+class :core:network kotlin-multiplatform
+class :feature:login kotlin-multiplatform
+class :androidApp android-application
+
+```
 ## ✨ Technologies Used
 
 This project leverages the following powerful technologies:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,4 +8,10 @@ plugins {
     alias(libs.plugins.composeMultiplatform).apply(false)
     alias(libs.plugins.kotlin.serialization).apply(false)
     alias(libs.plugins.kotlin.parcelize).apply(false)
+    alias(libs.plugins.modulegraph).apply(true)
+}
+
+moduleGraphConfig {
+    heading.set("## Module Graph")
+    setStyleByModuleType.set(true)
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -64,6 +64,7 @@ compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "
 composeMultiplatform = { id = "org.jetbrains.compose", version.ref = "compose-multiplatform" }
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 kotlin-parcelize = { id = "org.jetbrains.kotlin.plugin.parcelize", version.ref = "kotlin" }
+modulegraph = { id = "dev.iurysouza.modulegraph", version = "0.12.0" }
 
 #
 recipes-convention-publish = { id = "recipes.convention.publish", version = "unspecified" }


### PR DESCRIPTION
This commit introduces a module graph visualization to the `README.md` file.

Key changes:
- Added the `dev.iurysouza.modulegraph` plugin (version 0.12.0) to `gradle/libs.versions.toml`.
- Applied and configured the `moduleGraph` plugin in the root `build.gradle.kts` to set the heading and enable styling by module type.
- Added a "Module Graph" section to `README.md` with a Mermaid diagram visualizing the project's module dependencies and types.