### PR TITLE
feat: Integrate Firebase Crashlytics for Android and iOS

### DIFF
--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -1,8 +1,11 @@
+import com.google.firebase.crashlytics.buildtools.gradle.CrashlyticsExtension
+
 plugins {
     alias(libs.plugins.androidApplication)
     alias(libs.plugins.kotlinAndroid)
     alias(libs.plugins.compose.compiler)
     alias(libs.plugins.google.services)
+    alias(libs.plugins.firebase.crashlytics)
 }
 
 android {
@@ -26,7 +29,12 @@ android {
     }
     buildTypes {
         getByName("release") {
-            isMinifyEnabled = false
+            isMinifyEnabled = true
+            isShrinkResources = true
+            proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro")
+            configure<CrashlyticsExtension> {
+                mappingFileUploadEnabled = true
+            }
         }
     }
     compileOptions {

--- a/androidApp/proguard-rules.pro
+++ b/androidApp/proguard-rules.pro
@@ -1,0 +1,26 @@
+# Add project specific ProGuard rules here.
+# You can control the set of applied configuration files using the
+# proguardFiles setting in build.gradle.kts.
+#
+# For more details, see
+#   http://developer.android.com/guide/developing/tools/proguard.html
+
+# If your project uses WebView with JS, uncomment the following
+# and specify the fully qualified class name to the JavaScript interface
+# class:
+#-keepclassmembers class fqcn.of.javascript.interface.for.webview {
+#   public *;
+#}
+
+# Crashlytics
+-keep public class * extends java.lang.Exception  # Keep custom exceptions.
+
+# Uncomment this to preserve the line number information for
+# debugging stack traces.
+-keepattributes SourceFile,LineNumberTable
+
+# If you keep the line number information, uncomment this to
+# hide the original source file name.
+-renamesourcefileattribute SourceFile
+
+-printconfiguration full-r8-config.txt

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,6 +8,7 @@ plugins {
     alias(libs.plugins.composeMultiplatform).apply(false)
     alias(libs.plugins.kotlin.serialization).apply(false)
     alias(libs.plugins.google.services).apply(false)
+    alias(libs.plugins.firebase.crashlytics).apply(false)
     alias(libs.plugins.modulegraph).apply(true)
 }
 

--- a/core/common/build.gradle.kts
+++ b/core/common/build.gradle.kts
@@ -13,6 +13,8 @@ kotlin {
         androidMain.dependencies {
             implementation(compose.preview)
             implementation(libs.androidx.activity.compose)
+            implementation(project.dependencies.platform(libs.firebase.bom))
+            implementation(libs.firebase.crashlytics.ktx)
         }
         commonMain.dependencies {
             implementation(compose.runtime)

--- a/core/common/src/androidMain/AndroidManifest.xml
+++ b/core/common/src/androidMain/AndroidManifest.xml
@@ -1,4 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
+    <application>
+        <meta-data
+            android:name="firebase_crashlytics_collection_enabled"
+            android:value="true" />
+    </application>
 </manifest>

--- a/core/common/src/androidMain/kotlin/br/com/ricarlo/common/CrashlyticsLogger.android.kt
+++ b/core/common/src/androidMain/kotlin/br/com/ricarlo/common/CrashlyticsLogger.android.kt
@@ -1,0 +1,34 @@
+package br.com.ricarlo.common
+
+import com.google.firebase.crashlytics.FirebaseCrashlytics
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+
+internal class CrashlyticsLoggerImpl(
+    private val firebaseCrashlytics: FirebaseCrashlytics,
+    private val scope: CoroutineScope
+): CrashlyticsLogger {
+    override fun log(message: String) {
+        scope.launch {
+            firebaseCrashlytics.log(message)
+        }
+    }
+
+    override fun recordException(throwable: Throwable) {
+        scope.launch {
+            firebaseCrashlytics.recordException(throwable)
+        }
+    }
+
+    override fun setUserId(userId: String) {
+        scope.launch {
+            firebaseCrashlytics.setUserId(userId)
+        }
+    }
+
+    override fun setCustomKey(key: String, value: Any) {
+        scope.launch {
+            firebaseCrashlytics.setCustomKey(key, "$value")
+        }
+    }
+}

--- a/core/common/src/androidMain/kotlin/br/com/ricarlo/common/di/CommonModule.android.kt
+++ b/core/common/src/androidMain/kotlin/br/com/ricarlo/common/di/CommonModule.android.kt
@@ -1,0 +1,13 @@
+package br.com.ricarlo.common.di
+
+import br.com.ricarlo.common.CrashlyticsLogger
+import br.com.ricarlo.common.CrashlyticsLoggerImpl
+import com.google.firebase.crashlytics.FirebaseCrashlytics
+import org.koin.core.module.Module
+import org.koin.core.module.dsl.singleOf
+import org.koin.dsl.bind
+
+internal actual fun Module.others() {
+    singleOf(::CrashlyticsLoggerImpl) bind CrashlyticsLogger::class
+    single { FirebaseCrashlytics.getInstance() }
+}

--- a/core/common/src/commonMain/kotlin/br/com/ricarlo/common/CrashlyticsLogger.kt
+++ b/core/common/src/commonMain/kotlin/br/com/ricarlo/common/CrashlyticsLogger.kt
@@ -1,0 +1,8 @@
+package br.com.ricarlo.common
+
+interface CrashlyticsLogger {
+    fun log(message: String)
+    fun recordException(throwable: Throwable)
+    fun setUserId(userId: String)
+    fun setCustomKey(key: String, value: Any)
+}

--- a/core/common/src/commonMain/kotlin/br/com/ricarlo/common/di/CommonModule.kt
+++ b/core/common/src/commonMain/kotlin/br/com/ricarlo/common/di/CommonModule.kt
@@ -6,6 +6,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.IO
 import kotlinx.coroutines.SupervisorJob
+import org.koin.core.module.Module
 import org.koin.core.module.dsl.singleOf
 import org.koin.dsl.bind
 import org.koin.dsl.module
@@ -13,4 +14,7 @@ import org.koin.dsl.module
 val commonModule = module {
     singleOf(::DeepLinkHandler) bind IDeepLinkHandler::class
     factory<CoroutineScope> { CoroutineScope(Dispatchers.IO + SupervisorJob()) }
+    others()
 }
+
+internal expect fun Module.others()

--- a/core/common/src/iosMain/kotlin/br/com/ricarlo/common/CrashlyticsLogger.ios.kt
+++ b/core/common/src/iosMain/kotlin/br/com/ricarlo/common/CrashlyticsLogger.ios.kt
@@ -1,0 +1,19 @@
+package br.com.ricarlo.common
+
+internal class CrashlyticsLoggerImpl: CrashlyticsLogger {
+    override fun log(message: String) {
+//        FIRCrashlytics.crashlytics().log(message)
+    }
+
+    override fun recordException(throwable: Throwable) {
+//        CrashlyticsHelper
+    }
+
+    override fun setUserId(userId: String) {
+//        FIRCrashlytics.crashlytics().setUserId(userId)
+    }
+
+    override fun setCustomKey(key: String, value: Any) {
+//        FIRCrashlytics.crashlytics().setCustomKey(key, value)
+    }
+}

--- a/core/common/src/iosMain/kotlin/br/com/ricarlo/common/di/CommonModule.ios.kt
+++ b/core/common/src/iosMain/kotlin/br/com/ricarlo/common/di/CommonModule.ios.kt
@@ -1,0 +1,11 @@
+package br.com.ricarlo.common.di
+
+import br.com.ricarlo.common.CrashlyticsLogger
+import br.com.ricarlo.common.CrashlyticsLoggerImpl
+import org.koin.core.module.Module
+import org.koin.core.module.dsl.singleOf
+import org.koin.dsl.bind
+
+internal actual fun Module.others() {
+    singleOf(::CrashlyticsLoggerImpl) bind CrashlyticsLogger::class
+}

--- a/feature/login/src/commonMain/kotlin/br/com/ricarlo/login/presentation/LoginViewModel.kt
+++ b/feature/login/src/commonMain/kotlin/br/com/ricarlo/login/presentation/LoginViewModel.kt
@@ -3,6 +3,8 @@ package br.com.ricarlo.login.presentation
 import androidx.compose.runtime.Stable
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import br.com.ricarlo.common.CrashlyticsLogger
+import br.com.ricarlo.login.BuildConfig
 import br.com.ricarlo.login.domain.repository.AuthRepository
 import dev.icerock.moko.permissions.DeniedAlwaysException
 import dev.icerock.moko.permissions.DeniedException
@@ -18,7 +20,8 @@ import kotlinx.coroutines.launch
 
 internal class LoginViewModel(
     val permissionsController: PermissionsController,
-    private val authRepository: AuthRepository
+    private val authRepository: AuthRepository,
+    private val crashlyticsLogger: CrashlyticsLogger,
 ) : ViewModel() {
     private val _state = MutableStateFlow(LoginState())
     val state = _state.asStateFlow()
@@ -28,6 +31,8 @@ internal class LoginViewModel(
 
     init {
         requestPermission(Permission.REMOTE_NOTIFICATION)
+        crashlyticsLogger.setCustomKey(key = "FLAVOR", value = BuildConfig.FLAVOR)
+        crashlyticsLogger.recordException(NoSuchElementException("test..."))
     }
 
     fun onAction(action: LoginAction) {
@@ -62,6 +67,7 @@ internal class LoginViewModel(
                     username = state.value.username,
                     password = state.value.password
                 )
+                crashlyticsLogger.setUserId(userId = state.value.username)
             }.onSuccess {
                 _state.update { it.loading(false) }
                 _sideEffect.emit(LoginSideEffect.Navigate(route = "home"))

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -24,6 +24,7 @@ androidx-junit = { module = "androidx.test.ext:junit", version.ref = "junit" }
 firebase-bom = { module = "com.google.firebase:firebase-bom", version = "33.16.0" }
 firebase-analytics-ktx = { module = "com.google.firebase:firebase-analytics-ktx" }
 firebase-messaging-ktx = { module = "com.google.firebase:firebase-messaging-ktx" }
+firebase-crashlytics-ktx = { module = "com.google.firebase:firebase-crashlytics-ktx" }
 
 ktor-client-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }
 ktor-client-okhttp = { module = "io.ktor:ktor-client-okhttp", version.ref = "ktor" }
@@ -65,6 +66,7 @@ composeMultiplatform = { id = "org.jetbrains.compose", version.ref = "compose-mu
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 google-services = { id = "com.google.gms.google-services", version = "4.4.3" }
 modulegraph = { id = "dev.iurysouza.modulegraph", version = "0.12.0" }
+firebase-crashlytics = { id = "com.google.firebase.crashlytics", version = "3.0.4" }
 
 #
 recipes-convention-publish = { id = "recipes.convention.publish", version = "unspecified" }

--- a/iosApp/Podfile
+++ b/iosApp/Podfile
@@ -4,4 +4,5 @@ target 'iosApp' do
   pod 'shared', :path => '../shared'
   pod 'FirebaseAnalytics'
   pod 'FirebaseMessaging'
+  pod 'FirebaseCrashlytics'
 end

--- a/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -112,6 +112,8 @@
 				538A5EACDCB78535FB64FA0C /* Frameworks */,
 				3D08C70852322BCFF2271F57 /* [CP] Copy Pods Resources */,
 				7C8B270278C7F418102FF38C /* [CP] Embed Pods Frameworks */,
+				3160D8582E25DF36003800F2 /* ShellScript */,
+				3160D8592E25E773003800F2 /* ShellScript */,
 			);
 			buildRules = (
 			);
@@ -169,6 +171,42 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
+		3160D8582E25DF36003800F2 /* ShellScript */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${DWARF_DSYM_FOLDER_PATH}/${DWARF_DSYM_FILE_NAME}/Contents/Resources/DWARF/${TARGET_NAME}\n",
+				"$(SRCROOT)/$(BUILT_PRODUCTS_DIR)/$(INFOPLIST_PATH)",
+			);
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "# Type a script or drag a script file from your workspace to insert its path.\n\"${PODS_ROOT}/FirebaseCrashlytics/run\"\n";
+		};
+		3160D8592E25E773003800F2 /* ShellScript */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "# Type a script or drag a script file from your workspace to insert its path.\n${PODS_ROOT}/FirebaseCrashlytics/upload-symbols -gsp ${PROJECT_DIR}/iosApp/GoogleService-Info.plist -p ios ${DWARF_DSYM_FOLDER_PATH}/${DWARF_DSYM_FILE_NAME}\n\n";
+		};
 		3D08C70852322BCFF2271F57 /* [CP] Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;

--- a/iosApp/iosApp/iOSApp.swift
+++ b/iosApp/iosApp/iOSApp.swift
@@ -1,4 +1,5 @@
 import FirebaseCore
+import FirebaseCrashlytics
 import FirebaseMessaging
 import SwiftUI
 import UserNotifications
@@ -17,6 +18,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             .LaunchOptionsKey: Any]?
     ) -> Bool {
         FirebaseApp.configure()
+        Crashlytics.crashlytics().setCrashlyticsCollectionEnabled(true)
 
         // [START set_messaging_delegate]
         Messaging.messaging().delegate = self


### PR DESCRIPTION
This commit integrates Firebase Crashlytics for crash reporting on both Android and iOS platforms.

**Key Changes:**

- **Dependencies & Plugins:**
    - Added `firebase-crashlytics-ktx` to `gradle/libs.versions.toml`.
    - Added `com.google.firebase.crashlytics` plugin to the root `build.gradle.kts` and applied it in `androidApp/build.gradle.kts`.
    - Added `FirebaseCrashlytics` pod to `iosApp/Podfile`.
- **Core Common Module (`core/common`):**
    - Introduced a `CrashlyticsLogger` interface for platform-agnostic logging.
    - Implemented `CrashlyticsLoggerImpl` for Android and iOS:
        - **Android:** Uses `FirebaseCrashlytics` and a `CoroutineScope` for async operations. Provides `FirebaseCrashlytics` instance via Koin.
        - **iOS:** Placeholder implementation for `CrashlyticsLoggerImpl` (actual FIRCrashlytics calls are commented out and need native integration).
    - Added `CrashlyticsLogger` to the Koin `commonModule` using platform-specific `others()` extension functions.
    - Added `firebase_crashlytics_collection_enabled` meta-data to `androidMain/AndroidManifest.xml`.
- **Android App (`androidApp`):**
    - Enabled Proguard/R8 for release builds (`isMinifyEnabled = true`, `isShrinkResources = true`).
    - Added `proguard-rules.pro` with rules for Crashlytics and keeping custom exceptions.
    - Configured `CrashlyticsExtension` to enable mapping file uploads for release builds.
- **iOS App (`iosApp`):**
    - Added build phases to `project.pbxproj` for running Firebase Crashlytics scripts (`run` and `upload-symbols`).
    - Initialized Firebase Crashlytics and enabled collection in `iOSApp.swift`.
- **Feature Login (`feature/login`):**
    - Injected `CrashlyticsLogger` into `LoginViewModel`.
    - Added example usage: setting a custom key ("FLAVOR") and recording a test exception.
    - Set user ID in Crashlytics after a successful login.